### PR TITLE
fix: bump rexml to 3.4.2 (CVE-2025-58767)

### DIFF
--- a/multiprogramexample/Gemfile.lock
+++ b/multiprogramexample/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.1)
+    rexml (3.4.2)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
     typhoeus (1.4.1)

--- a/nutritionistexample/Gemfile.lock
+++ b/nutritionistexample/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.1)
+    rexml (3.4.2)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
     typhoeus (1.4.1)

--- a/reactnativeexample/Gemfile.lock
+++ b/reactnativeexample/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.1)
+    rexml (3.4.2)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
     typhoeus (1.4.1)


### PR DESCRIPTION
## Summary
Bumps `rexml` `3.4.1` → `3.4.2` in all three example-app `Gemfile.lock` files, clearing **CVE-2025-58767** (REXML denial of service, fixed in `>= 3.4.2`).

`rexml` is a transitive Ruby dependency with only a range constraint (`>= 3.3.6, < 4.0`), so the one-line bump per lockfile keeps each lock consistent — same low-risk approach as the `activesupport` fix in #21.

## Verification
`trivy fs --scanners vuln` (trivy 0.69.3) on all three `Gemfile.lock` files:
- Before: 1 finding each — `rexml` CVE-2025-58767 (MEDIUM).
- After: **0 findings** on every `Gemfile.lock`.

## Note — not in scope here
The npm `package-lock.json` files still carry ~12 MEDIUM findings each (an `axios` CVE cluster, `markdown-it`, `postcss`). Those don't break CI (`trivy-scan` gates HIGH/CRITICAL only) and need a proper dependency-upgrade pass rather than a lockfile line-edit — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)